### PR TITLE
Use LinkedHashMap for deterministic iteration order

### DIFF
--- a/src/test/java/org/fluentd/logger/sender/TestSenderFluentdDownOperation.java
+++ b/src/test/java/org/fluentd/logger/sender/TestSenderFluentdDownOperation.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertArrayEquals;
 import java.io.IOException;
 import java.net.Socket;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.fluentd.logger.sender.RawSocketSender;
@@ -31,7 +32,7 @@ public class TestSenderFluentdDownOperation {
 
         // start senders
         RawSocketSender sender = new RawSocketSender("localhost", port);
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new LinkedHashMap<String, Object>();
         data.put("t1k1", "t1v1");
         data.put("t1k2", "t1v2");
         sender.emit("tag.label1", timestamp, data);
@@ -40,7 +41,7 @@ public class TestSenderFluentdDownOperation {
         byte[] bytes1 = packer.toByteArray();
         assertArrayEquals(bytes1, sender.getBuffer());
 
-        Map<String, Object> data2 = new HashMap<String, Object>();
+        Map<String, Object> data2 = new LinkedHashMap<String, Object>();
         data2.put("t2k1", "t2v1");
         data2.put("t2k2", "t2v2");
         sender.emit("tag.label2", timestamp, data2);
@@ -83,7 +84,7 @@ public class TestSenderFluentdDownOperation {
         // sleep a little bit
         Thread.sleep(1000);
 
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new LinkedHashMap<String, Object>();
         data.put("t1k1", "t1v1");
         data.put("t1k2", "t1v2");
         for (int i = 0; i < 3; ++i) {
@@ -95,7 +96,7 @@ public class TestSenderFluentdDownOperation {
         byte[] bytes1 = packer.toByteArray();
         assertArrayEquals(bytes1, sender.getBuffer());
 
-        Map<String, Object> data2 = new HashMap<String, Object>();
+        Map<String, Object> data2 = new LinkedHashMap<String, Object>();
         data2.put("t2k1", "t2v1");
         data2.put("t2k2", "t2v2");
         sender.emit("tag.label2", data2);


### PR DESCRIPTION
The test `org.fluentd.logger.sender.TestRawSocketSender#testReconnectAfterBufferFull` can fail due to a different iteration order of HashMap.

The fix is to change HaskMap to LinkedHashMap so that the iteration order remains stable and the failure will not occur any more. In this way, the test will be more stable.